### PR TITLE
Stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-tungstenite",
  "tungstenite",
@@ -942,6 +943,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bindgen"
-version = "0.54.1"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d49b80beb70d76cdac92f5681e666f9a697c737c4f4117a67229a0386dc736"
+checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -106,9 +106,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
 
 [[package]]
 name = "cexpr"
@@ -127,9 +127,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clang-sys"
-version = "0.29.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
+checksum = "9da1484c6a890e374ca5086062d4847e0a2c1e5eba9afa5d48c09e8eb39b2519"
 dependencies = [
  "glob",
  "libc",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.1"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
@@ -397,23 +397,23 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.74"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+checksum = "2443d8f0478b16759158b2f66d525991a05491138bc05814ef52a250148ef4f9"
 dependencies = [
- "cc",
+ "cfg-if",
  "winapi 0.3.9",
 ]
 
@@ -666,9 +666,9 @@ checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
 dependencies = [
  "unicode-xid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+
+[[package]]
 name = "arc-swap"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +683,7 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 name = "quinte"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bindgen",
  "env_logger",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,17 +9,17 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libc = "0.2.74"
-tokio = { version = "0.2.22", features = ["full"] }
-tokio-tungstenite = "0.11.0"
-log = "0.4.11"
-env_logger = "0.7.1"
-tungstenite = "0.11.1"
-futures-util = "0.3.5"
-serde = { version = "1.0.115", features = ["derive"] }
-serde_json = "1.0.57"
-thiserror = "1.0.20"
-anyhow = "1.0.32"
+anyhow = "1.0"
+env_logger = "0.7"
+futures-util = "0.3"
+libc = "0.2"
+log = "0.4"
+serde = {version = "1.0", features = ["derive"]}
+serde_json = "1.0"
+thiserror = "1.0"
+tokio = {version = "0.2", features = ["full"]}
+tokio-tungstenite = "0.11"
+tungstenite = "0.11"
 
 [build-dependencies]
-bindgen = "0.54.1"
+bindgen = "0.55"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ futures-util = "0.3.5"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
 thiserror = "1.0.20"
+anyhow = "1.0.32"
 
 [build-dependencies]
 bindgen = "0.54.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tungstenite = "0.11.1"
 futures-util = "0.3.5"
 serde = { version = "1.0.115", features = ["derive"] }
 serde_json = "1.0.57"
+thiserror = "1.0.20"
 
 [build-dependencies]
 bindgen = "0.54.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,19 @@ pub mod server;
 
 use std::{ffi::CStr, os::raw};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Invalid CString")]
     CString,
+    #[error("Failed to parse frame: {0:?}")]
     FrameParse(String),
+    #[error("Internal error ({0:?})")]
     Internal(&'static str),
+    #[error("Failed to search")]
     NotmuchSearch,
+    #[error("Unknown Payload")]
     UnknownPayload,
+    #[error("Websocket Error: {0:?}")]
     WebSocket(String),
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "info");
+    }
     env_logger::init();
     info!("Quinte Server");
 

--- a/src/notmuch/mod.rs
+++ b/src/notmuch/mod.rs
@@ -15,11 +15,12 @@ use std::os::raw;
 use std::ptr;
 use tokio::sync::Mutex;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum NotmuchError {
+    #[error("Invalid CString")]
     FfiCString(std::ffi::NulError),
+    #[error("{0}")]
     DbFailedToOpen(String),
-    SearchMessagesFailed,
 }
 
 impl From<std::ffi::NulError> for NotmuchError {


### PR DESCRIPTION
* I like setting RUST_LOG to info by default because I rarely want to log nothing
* thiserror is useful to implement `std::error::Error` for custom types (the popular approach right now is to use thiserror in libraries for library error types and to use anyhow (or eyre or something similar) in application code where the different error types don't need to be disambiguated
* anyhow for contexts and because it makes handling all error types the same very easy (which is fine if all we're doing is printing an error message)
and dependency bump